### PR TITLE
Fix implementation not being in accordance with specs

### DIFF
--- a/src/mgos_sntp.c
+++ b/src/mgos_sntp.c
@@ -113,6 +113,7 @@ static void mgos_sntp_retry(void) {
   int rt_ms = 0;
   if (s_state.synced) {
     rt_ms = mgos_sys_config_get_sntp_update_interval() * 1000;
+    if (rt_ms == 0) return;
   } else {
     rt_ms = s_state.retry_timeout_ms * 2;
     if (rt_ms < mgos_sys_config_get_sntp_retry_min() * 1000) {


### PR DESCRIPTION
Fix implementation not being in accordance with specs:
	"Update interval. If 0, performs a one-off sync"

Signed-off-by: Sergio R. Caprile <scaprile@gmail.com>