### PR TITLE
Add mgos_sntp_get_last_synced_uptime()

### DIFF
--- a/include/mgos_sntp.h
+++ b/include/mgos_sntp.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <stdbool.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * Returns 0 until synced. After that, returns uptime in seconds of the
+ * last sync event, as returned by `mgos_uptime()`.
+ */
+double mgos_sntp_get_last_synced_uptime(void);
+
+#ifdef __cplusplus
+}
+#endif

--- a/mos.yml
+++ b/mos.yml
@@ -5,6 +5,8 @@ version: 1.0
 
 sources:
   - src
+includes:
+  - include
 filesystem:
   - fs
 config_schema:


### PR DESCRIPTION
Okay, force-pushing a branch to it's merge-base with the upstream main branch automatically closes the associated pull request. Sorry about the duplicate.

This adds `double mgos_sntp_get_last_synced_uptime()` as proposed in https://github.com/mongoose-os-libs/sntp/pull/3 , but keeps `bool mgos_sntp_is_synced()` since that's what is needed most frequently anyway, including in the source of this lib itself.